### PR TITLE
Add safeties, WholeBodyControl config for LCM2ROSControl, and better hand joint limits

### DIFF
--- a/config/HandControl.yaml
+++ b/config/HandControl.yaml
@@ -23,49 +23,49 @@ HandPositionGoalController:
     joint_limits:
         leftIndexFingerMotorPitch1:
             has_position_limits: true
-            min_position: 0.0
+            min_position: 0.5
             max_position: 2.0
         leftMiddleFingerMotorPitch1:
             has_position_limits: true
-            min_position: 0.0
+            min_position: 0.5
             max_position: 2.0
         leftPinkyMotorPitch1:
             has_position_limits: true
-            min_position: 0.0
+            min_position: 0.5
             max_position: 2.0
         leftThumbMotorPitch1:
             has_position_limits: true
-            min_position: 0.0
+            min_position: 0.5
             max_position: 2.0
         leftThumbMotorPitch2:
             has_position_limits: true
-            min_position: 0.0
+            min_position: 0.5
             max_position: 2.0
         leftThumbMotorRoll:
             has_position_limits: true
-            min_position: 0.0
+            min_position: 0.5
             max_position: 1.7
         rightIndexFingerMotorPitch1:
             has_position_limits: true
-            min_position: 0.0
+            min_position: 0.5
             max_position: 2.8
         rightMiddleFingerMotorPitch1:
             has_position_limits: true
-            min_position: 0.0
+            min_position: 0.5
             max_position: 3.0
         rightPinkyMotorPitch1:
             has_position_limits: true
-            min_position: 0.0
+            min_position: 0.5
             max_position: 2.5
         rightThumbMotorPitch1:
             has_position_limits: true
-            min_position: 0.0
+            min_position: 0.5
             max_position: 1.6
         rightThumbMotorPitch2:
             has_position_limits: true
-            min_position: 0.0
+            min_position: 0.5
             max_position: 1.5 # depends on setting of rightThumbMotorPitch1
         rightThumbMotorRoll:
             has_position_limits: true
-            min_position: 0.0
+            min_position: 0.5
             max_position: 1.7

--- a/config/HandControl.yaml
+++ b/config/HandControl.yaml
@@ -7,32 +7,32 @@ HandPositionGoalController:
     control_state_channel: "HAND_STATE"
     control_state_publish_frequency: 50
     joints: # Position-commanded joints
-        # - leftIndexFingerMotorPitch1
-        # - leftMiddleFingerMotorPitch1
-        # - leftPinkyMotorPitch1
-        # - leftThumbMotorPitch1
-        # - leftThumbMotorPitch2
+         - leftIndexFingerMotorPitch1
+         - leftMiddleFingerMotorPitch1
+         - leftPinkyMotorPitch1
+         - leftThumbMotorPitch1
+         - leftThumbMotorPitch2
         # - leftThumbMotorRoll
-        - rightIndexFingerMotorPitch1
-        - rightMiddleFingerMotorPitch1
-        - rightPinkyMotorPitch1
-        - rightThumbMotorPitch1
-        - rightThumbMotorPitch2
-        - rightThumbMotorRoll
-    joint_velocity_limit: 0.262 # rad/s
+        #- rightIndexFingerMotorPitch1
+        #- rightMiddleFingerMotorPitch1
+        #- rightPinkyMotorPitch1
+        #- rightThumbMotorPitch1
+        #- rightThumbMotorPitch2
+        #- rightThumbMotorRoll
+    joint_velocity_limit: 1.0 # rad/s
     joint_limits:
         leftIndexFingerMotorPitch1:
             has_position_limits: true
             min_position: 0.5
-            max_position: 2.0
+            max_position: 2.5
         leftMiddleFingerMotorPitch1:
             has_position_limits: true
             min_position: 0.5
-            max_position: 2.0
+            max_position: 2.7
         leftPinkyMotorPitch1:
             has_position_limits: true
             min_position: 0.5
-            max_position: 2.0
+            max_position: 2.7
         leftThumbMotorPitch1:
             has_position_limits: true
             min_position: 0.5
@@ -44,23 +44,23 @@ HandPositionGoalController:
         leftThumbMotorRoll:
             has_position_limits: true
             min_position: 0.5
-            max_position: 1.7
+            max_position: 1.5
         rightIndexFingerMotorPitch1:
             has_position_limits: true
             min_position: 0.5
-            max_position: 2.8
+            max_position: 2.0
         rightMiddleFingerMotorPitch1:
             has_position_limits: true
             min_position: 0.5
-            max_position: 3.0
+            max_position: 2.0
         rightPinkyMotorPitch1:
             has_position_limits: true
             min_position: 0.5
-            max_position: 2.5
+            max_position: 2.0
         rightThumbMotorPitch1:
             has_position_limits: true
             min_position: 0.5
-            max_position: 1.6
+            max_position: 1.5
         rightThumbMotorPitch2:
             has_position_limits: true
             min_position: 0.5
@@ -68,4 +68,4 @@ HandPositionGoalController:
         rightThumbMotorRoll:
             has_position_limits: true
             min_position: 0.5
-            max_position: 1.7
+            max_position: 1.5

--- a/config/LCM2ROSControl.yaml
+++ b/config/LCM2ROSControl.yaml
@@ -1,2 +1,5 @@
 LCM2ROSControl:
     type: valkyrie_translator/LCM2ROSControl
+    publish_core_robot_state:  true
+    publish_est_robot_state: false
+    apply_commands: false

--- a/config/WholeBodyControl.yaml
+++ b/config/WholeBodyControl.yaml
@@ -2,7 +2,7 @@ LCM2ROSControl:
     type: valkyrie_translator/LCM2ROSControl
     publish_core_robot_state:  true
     publish_est_robot_state: false
-    apply_commands: false    
+    apply_commands: false
 
     joints:
       - torsoYaw
@@ -43,3 +43,11 @@ LCM2ROSControl:
         max_position: 1.0
         has_effort_limits: true
         max_effort: 100.0
+
+      leftShoulderRoll:
+        has_position_limits: true
+        min_position: -1.51
+        max_position: 1.5
+        has_effort_limits: true
+        max_effort: 100.0
+         

--- a/config/WholeBodyControl.yaml
+++ b/config/WholeBodyControl.yaml
@@ -1,0 +1,45 @@
+LCM2ROSControl:
+    type: valkyrie_translator/LCM2ROSControl
+    publish_core_robot_state:  true
+    publish_est_robot_state: false
+    apply_commands: false    
+
+    joints:
+      - torsoYaw
+      - torsoPitch
+      - torsoRoll
+      - lowerNeckPitch
+      - leftHipYaw
+      - leftHipRoll
+      - leftHipPitch
+      - leftKneePitch
+      - leftAnklePitch
+      - leftAnkleRoll
+      - rightHipYaw
+      - rightHipRoll
+      - rightHipPitch
+      - rightKneePitch
+      - rightAnklePitch
+      - rightAnkleRoll
+      - leftShoulderPitch
+      - leftShoulderRoll
+      - leftShoulderYaw
+      - leftElbowPitch
+      - leftForearm
+      - leftWristRoll
+      - leftWristPitch
+      - rightShoulderPitch
+      - rightShoulderRoll
+      - rightShoulderYaw
+      - rightElbowPitch
+      - rightForearm
+      - rightWristRoll
+      - rightWristPitch
+
+    joint_limits:
+      torsoYaw:
+        has_position_limits: true
+        min_position: -1.0
+        max_position: 1.0
+        has_effort_limits: true
+        max_effort: 100.0

--- a/launch/WholeBodyControl.launch
+++ b/launch/WholeBodyControl.launch
@@ -1,0 +1,9 @@
+<launch>
+
+  <!-- Load joint controller configurations from YAML file to parameter server -->
+  <rosparam file="$(find valkyrie_translator)/config/WholeBodyControl.yaml" command="load"/>
+
+  <!-- load the controllers -->
+  <node name="LCM2ROSControl_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="LCM2ROSControl"/>
+
+</launch>

--- a/src/LCM2ROSControl.cpp
+++ b/src/LCM2ROSControl.cpp
@@ -19,288 +19,288 @@ wolfgang.merkt@ed.ac.uk, 201603**
 
 namespace valkyrie_translator
 {
-   LCM2ROSControl::LCM2ROSControl()
-   {}
+ LCM2ROSControl::LCM2ROSControl()
+ {}
 
-   LCM2ROSControl::~LCM2ROSControl()
-   {}
+ LCM2ROSControl::~LCM2ROSControl()
+ {}
 
-    bool LCM2ROSControl::initRequest(hardware_interface::RobotHW* robot_hw,
-                             ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh,
-                             std::set<std::string>& claimed_resources)
-    {
+ bool LCM2ROSControl::initRequest(hardware_interface::RobotHW* robot_hw,
+   ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh,
+   std::set<std::string>& claimed_resources)
+ {
         // check if construction finished cleanly
-        if (state_ != CONSTRUCTED){
-          ROS_ERROR("Cannot initialize this controller because it failed to be constructed");
-          return false;
-        }
+  if (state_ != CONSTRUCTED){
+    ROS_ERROR("Cannot initialize this controller because it failed to be constructed");
+    return false;
+  }
 
         // setup LCM (todo: move to constructor? how to propagate an error then?)
-        lcm_ = boost::shared_ptr<lcm::LCM>(new lcm::LCM);
-        if (!lcm_->good())
-        {
-          std::cerr << "ERROR: lcm is not good()" << std::endl;
-          return false;
-        }
-        handler_ = std::shared_ptr<LCM2ROSControl_LCMHandler>(new LCM2ROSControl_LCMHandler(*this));
+  lcm_ = boost::shared_ptr<lcm::LCM>(new lcm::LCM);
+  if (!lcm_->good())
+  {
+    std::cerr << "ERROR: lcm is not good()" << std::endl;
+    return false;
+  }
+  handler_ = std::shared_ptr<LCM2ROSControl_LCMHandler>(new LCM2ROSControl_LCMHandler(*this));
 
         // Check which joints we have been assigned to
         // If we have joints assigned to just us, claim those, otherwise claim all
-        std::vector<std::string> joint_names_;
-        if (!controller_nh.getParam("joints", joint_names_))
-          ROS_INFO_STREAM("Could not get assigned list of joints, will resume to claim all");
+  std::vector<std::string> joint_names_;
+  if (!controller_nh.getParam("joints", joint_names_))
+    ROS_INFO_STREAM("Could not get assigned list of joints, will resume to claim all");
 
-        auto n_joints_ = joint_names_.size();
-        bool use_joint_selection = true;
-        if (n_joints_ == 0)
-          use_joint_selection = false;
+  auto n_joints_ = joint_names_.size();
+  bool use_joint_selection = true;
+  if (n_joints_ == 0)
+    use_joint_selection = false;
 
         // get a pointer to the effort interface
-        hardware_interface::EffortJointInterface* effort_hw = robot_hw->get<hardware_interface::EffortJointInterface>();
-        if (!effort_hw)
-        {
-          ROS_ERROR("This controller requires a hardware interface of type hardware_interface::EffortJointInterface.");
-          return false;
-        }
+  hardware_interface::EffortJointInterface* effort_hw = robot_hw->get<hardware_interface::EffortJointInterface>();
+  if (!effort_hw)
+  {
+    ROS_ERROR("This controller requires a hardware interface of type hardware_interface::EffortJointInterface.");
+    return false;
+  }
 
-        effort_hw->clearClaims();
-        const std::vector<std::string>& effortNames = effort_hw->getNames();
+  effort_hw->clearClaims();
+  const std::vector<std::string>& effortNames = effort_hw->getNames();
         // initialize command buffer for each joint we found on the HW
-        for (unsigned int i=0; i<effortNames.size(); i++)
-        {
-          if (use_joint_selection && std::find(joint_names_.begin(), joint_names_.end(), effortNames[i]) == joint_names_.end())
-            continue;
+  for (unsigned int i=0; i<effortNames.size(); i++)
+  {
+    if (use_joint_selection && std::find(joint_names_.begin(), joint_names_.end(), effortNames[i]) == joint_names_.end())
+      continue;
 
-          try {
-            effortJointHandles[effortNames[i]] = effort_hw->getHandle(effortNames[i]);
-            latest_commands[effortNames[i]] = joint_command();
-            latest_commands[effortNames[i]].position = 0.0;
-            latest_commands[effortNames[i]].velocity = 0.0;
-            latest_commands[effortNames[i]].effort = 0.0;
-            latest_commands[effortNames[i]].k_q_p = 0.0;
-            latest_commands[effortNames[i]].k_q_i = 0.0;
-            latest_commands[effortNames[i]].k_qd_p = 0.0;
-            latest_commands[effortNames[i]].k_f_p = 0.0;
-            latest_commands[effortNames[i]].ff_qd = 0.0;
-            latest_commands[effortNames[i]].ff_qd_d = 0.0;
-            latest_commands[effortNames[i]].ff_f_d = 0.0;
-            latest_commands[effortNames[i]].ff_const = 0.0;
-          } catch (const hardware_interface::HardwareInterfaceException& e) {
-            ROS_ERROR_STREAM("Could not retrieve handle for " << effortNames[i] << ": " << e.what());
-          }
-        }
+    try {
+      effortJointHandles[effortNames[i]] = effort_hw->getHandle(effortNames[i]);
+      latest_commands[effortNames[i]] = joint_command();
+      latest_commands[effortNames[i]].position = 0.0;
+      latest_commands[effortNames[i]].velocity = 0.0;
+      latest_commands[effortNames[i]].effort = 0.0;
+      latest_commands[effortNames[i]].k_q_p = 0.0;
+      latest_commands[effortNames[i]].k_q_i = 0.0;
+      latest_commands[effortNames[i]].k_qd_p = 0.0;
+      latest_commands[effortNames[i]].k_f_p = 0.0;
+      latest_commands[effortNames[i]].ff_qd = 0.0;
+      latest_commands[effortNames[i]].ff_qd_d = 0.0;
+      latest_commands[effortNames[i]].ff_f_d = 0.0;
+      latest_commands[effortNames[i]].ff_const = 0.0;
+    } catch (const hardware_interface::HardwareInterfaceException& e) {
+      ROS_ERROR_STREAM("Could not retrieve handle for " << effortNames[i] << ": " << e.what());
+    }
+  }
 
-        auto effort_hw_claims = effort_hw->getClaims();
-        claimed_resources.insert(effort_hw_claims.begin(), effort_hw_claims.end());
-        effort_hw->clearClaims();
+  auto effort_hw_claims = effort_hw->getClaims();
+  claimed_resources.insert(effort_hw_claims.begin(), effort_hw_claims.end());
+  effort_hw->clearClaims();
 
         // get a pointer to the position interface
-        hardware_interface::PositionJointInterface* position_hw = robot_hw->get<hardware_interface::PositionJointInterface>();
-        if (!position_hw)
-        {
-          ROS_ERROR("This controller requires a hardware interface of type hardware_interface::PositionJointInterface.");
-          return false;
-        }
+  hardware_interface::PositionJointInterface* position_hw = robot_hw->get<hardware_interface::PositionJointInterface>();
+  if (!position_hw)
+  {
+    ROS_ERROR("This controller requires a hardware interface of type hardware_interface::PositionJointInterface.");
+    return false;
+  }
 
-        position_hw->clearClaims();
-        const std::vector<std::string>& positionNames = position_hw->getNames();
+  position_hw->clearClaims();
+  const std::vector<std::string>& positionNames = position_hw->getNames();
         // initialize command buffer for each joint we found on the HW
-        for(unsigned int i=0; i<positionNames.size(); i++)
-        {
-          if (use_joint_selection && std::find(joint_names_.begin(), joint_names_.end(), positionNames[i]) == joint_names_.end())
-            continue;
+  for(unsigned int i=0; i<positionNames.size(); i++)
+  {
+    if (use_joint_selection && std::find(joint_names_.begin(), joint_names_.end(), positionNames[i]) == joint_names_.end())
+      continue;
 
-          try {
-            positionJointHandles[positionNames[i]] = position_hw->getHandle(positionNames[i]);
-            latest_commands[positionNames[i]] = joint_command();
-            latest_commands[positionNames[i]].position = 0.0;
-            latest_commands[positionNames[i]].velocity = 0.0;
-            latest_commands[positionNames[i]].effort = 0.0;
-            latest_commands[positionNames[i]].k_q_p = 0.0;
-            latest_commands[positionNames[i]].k_q_i = 0.0;
-            latest_commands[positionNames[i]].k_qd_p = 0.0;
-            latest_commands[positionNames[i]].k_f_p = 0.0;
-            latest_commands[positionNames[i]].ff_qd = 0.0;
-            latest_commands[positionNames[i]].ff_qd_d = 0.0;
-            latest_commands[positionNames[i]].ff_f_d = 0.0;
-            latest_commands[positionNames[i]].ff_const = 0.0;
-          } catch (const hardware_interface::HardwareInterfaceException& e) {
-            ROS_ERROR_STREAM("Could not retrieve handle for " << positionNames[i] << ": " << e.what());
-          }
-        }
+    try {
+      positionJointHandles[positionNames[i]] = position_hw->getHandle(positionNames[i]);
+      latest_commands[positionNames[i]] = joint_command();
+      latest_commands[positionNames[i]].position = 0.0;
+      latest_commands[positionNames[i]].velocity = 0.0;
+      latest_commands[positionNames[i]].effort = 0.0;
+      latest_commands[positionNames[i]].k_q_p = 0.0;
+      latest_commands[positionNames[i]].k_q_i = 0.0;
+      latest_commands[positionNames[i]].k_qd_p = 0.0;
+      latest_commands[positionNames[i]].k_f_p = 0.0;
+      latest_commands[positionNames[i]].ff_qd = 0.0;
+      latest_commands[positionNames[i]].ff_qd_d = 0.0;
+      latest_commands[positionNames[i]].ff_f_d = 0.0;
+      latest_commands[positionNames[i]].ff_const = 0.0;
+    } catch (const hardware_interface::HardwareInterfaceException& e) {
+      ROS_ERROR_STREAM("Could not retrieve handle for " << positionNames[i] << ": " << e.what());
+    }
+  }
 
-        auto position_hw_claims = position_hw->getClaims();
-        claimed_resources.insert(position_hw_claims.begin(), position_hw_claims.end());
-        position_hw->clearClaims();
+  auto position_hw_claims = position_hw->getClaims();
+  claimed_resources.insert(position_hw_claims.begin(), position_hw_claims.end());
+  position_hw->clearClaims();
 
         // get a pointer to the imu interface
-        hardware_interface::ImuSensorInterface* imu_hw = robot_hw->get<hardware_interface::ImuSensorInterface>();
-        if (!imu_hw)
-        {
-          ROS_ERROR("This controller requires a hardware interface of type hardware_interface::ImuSensorInterface.");
-          return false;
-        }
+  hardware_interface::ImuSensorInterface* imu_hw = robot_hw->get<hardware_interface::ImuSensorInterface>();
+  if (!imu_hw)
+  {
+    ROS_ERROR("This controller requires a hardware interface of type hardware_interface::ImuSensorInterface.");
+    return false;
+  }
 
-        imu_hw->clearClaims();
-        const std::vector<std::string>& imuNames = imu_hw->getNames();
-        for(unsigned int i=0; i<imuNames.size(); i++)
-        {
-          if (use_joint_selection && std::find(joint_names_.begin(), joint_names_.end(), imuNames[i]) == joint_names_.end())
-            continue;
+  imu_hw->clearClaims();
+  const std::vector<std::string>& imuNames = imu_hw->getNames();
+  for(unsigned int i=0; i<imuNames.size(); i++)
+  {
+    if (use_joint_selection && std::find(joint_names_.begin(), joint_names_.end(), imuNames[i]) == joint_names_.end())
+      continue;
 
-          try {
-            imuSensorHandles[imuNames[i]] = imu_hw->getHandle(imuNames[i]);
-          } catch (const hardware_interface::HardwareInterfaceException& e) {
-            ROS_ERROR_STREAM("Could not retrieve handle for " << imuNames[i] << ": " << e.what());
-          }
-        }
+    try {
+      imuSensorHandles[imuNames[i]] = imu_hw->getHandle(imuNames[i]);
+    } catch (const hardware_interface::HardwareInterfaceException& e) {
+      ROS_ERROR_STREAM("Could not retrieve handle for " << imuNames[i] << ": " << e.what());
+    }
+  }
 
-        auto imu_hw_claims = imu_hw->getClaims();
-        claimed_resources.insert(imu_hw_claims.begin(), imu_hw_claims.end());
-        imu_hw->clearClaims();
+  auto imu_hw_claims = imu_hw->getClaims();
+  claimed_resources.insert(imu_hw_claims.begin(), imu_hw_claims.end());
+  imu_hw->clearClaims();
 
-        hardware_interface::ForceTorqueSensorInterface* forceTorque_hw = robot_hw->get<hardware_interface::ForceTorqueSensorInterface>();
-        if (!forceTorque_hw)
-        {
-          ROS_ERROR("This controller requires a hardware interface of type hardware_interface::EffortJointInterface.");
-          return false;
-        }
+  hardware_interface::ForceTorqueSensorInterface* forceTorque_hw = robot_hw->get<hardware_interface::ForceTorqueSensorInterface>();
+  if (!forceTorque_hw)
+  {
+    ROS_ERROR("This controller requires a hardware interface of type hardware_interface::EffortJointInterface.");
+    return false;
+  }
 
         // get pointer to forcetorque interface
-        forceTorque_hw->clearClaims();
-        const std::vector<std::string>& forceTorqueNames = forceTorque_hw->getNames();
-        for(unsigned int i=0; i<forceTorqueNames.size(); i++)
-        {
-          if (use_joint_selection && std::find(joint_names_.begin(), joint_names_.end(), forceTorqueNames[i]) == joint_names_.end())
-            continue;
+  forceTorque_hw->clearClaims();
+  const std::vector<std::string>& forceTorqueNames = forceTorque_hw->getNames();
+  for(unsigned int i=0; i<forceTorqueNames.size(); i++)
+  {
+    if (use_joint_selection && std::find(joint_names_.begin(), joint_names_.end(), forceTorqueNames[i]) == joint_names_.end())
+      continue;
 
-          try {
-            forceTorqueHandles[forceTorqueNames[i]] = forceTorque_hw->getHandle(forceTorqueNames[i]);
-          } catch (const hardware_interface::HardwareInterfaceException& e) {
-            ROS_ERROR_STREAM("Could not retrieve handle for " << forceTorqueNames[i] << ": " << e.what());
-          }
-        }
-        auto forceTorque_hw_claims = forceTorque_hw->getClaims();
-        claimed_resources.insert(forceTorque_hw_claims.begin(), forceTorque_hw_claims.end());
-        forceTorque_hw->clearClaims();
+    try {
+      forceTorqueHandles[forceTorqueNames[i]] = forceTorque_hw->getHandle(forceTorqueNames[i]);
+    } catch (const hardware_interface::HardwareInterfaceException& e) {
+      ROS_ERROR_STREAM("Could not retrieve handle for " << forceTorqueNames[i] << ": " << e.what());
+    }
+  }
+  auto forceTorque_hw_claims = forceTorque_hw->getClaims();
+  claimed_resources.insert(forceTorque_hw_claims.begin(), forceTorque_hw_claims.end());
+  forceTorque_hw->clearClaims();
 
         // success
-        state_ = INITIALIZED;
-        ROS_INFO_STREAM("LCM2ROSCONTROL ON with " << claimed_resources.size() << " claimed resources:" << std::endl
-            << forceTorque_hw_claims.size() << " force torque" << std::endl
-            << imu_hw_claims.size() << " IMUs" << std::endl
-            << effort_hw_claims.size() << " effort-controlled joints" << std::endl
-            << position_hw_claims.size() << " position-controlled joints" << std::endl);
-        return true;
-    }
+  state_ = INITIALIZED;
+  ROS_INFO_STREAM("LCM2ROSCONTROL ON with " << claimed_resources.size() << " claimed resources:" << std::endl
+    << forceTorque_hw_claims.size() << " force torque" << std::endl
+    << imu_hw_claims.size() << " IMUs" << std::endl
+    << effort_hw_claims.size() << " effort-controlled joints" << std::endl
+    << position_hw_claims.size() << " position-controlled joints" << std::endl);
+  return true;
+}
 
-   void LCM2ROSControl::starting(const ros::Time& time)
-   {
-      last_update = time;
-   }
+void LCM2ROSControl::starting(const ros::Time& time)
+{
+  last_update = time;
+}
 
-   void LCM2ROSControl::update(const ros::Time& time, const ros::Duration& period)
-   {
-      handler_->update();
-      lcm_->handleTimeout(0);
+void LCM2ROSControl::update(const ros::Time& time, const ros::Duration& period)
+{
+  handler_->update();
+  lcm_->handleTimeout(0);
 
-      double dt = (time - last_update).toSec();
-      last_update = time;
-      int64_t utime = time.toSec() * 1000000.;
+  double dt = (time - last_update).toSec();
+  last_update = time;
+  int64_t utime = time.toSec() * 1000000.;
 
-      size_t numberOfJointInterfaces = effortJointHandles.size() + positionJointHandles.size();
+  size_t numberOfJointInterfaces = effortJointHandles.size() + positionJointHandles.size();
 
       // VAL_CORE_ROBOT_STATE
       // push out the joint states for all joints we see advertised
       // and also the commanded torques, for reference
-      bot_core::joint_state_t lcm_pose_msg;
-      lcm_pose_msg.utime = utime;
-      lcm_pose_msg.num_joints = numberOfJointInterfaces;
-      lcm_pose_msg.joint_name.assign(numberOfJointInterfaces, "");
-      lcm_pose_msg.joint_position.assign(numberOfJointInterfaces, 0.);
-      lcm_pose_msg.joint_velocity.assign(numberOfJointInterfaces, 0.);
-      lcm_pose_msg.joint_effort.assign(numberOfJointInterfaces, 0.);
+  bot_core::joint_state_t lcm_pose_msg;
+  lcm_pose_msg.utime = utime;
+  lcm_pose_msg.num_joints = numberOfJointInterfaces;
+  lcm_pose_msg.joint_name.assign(numberOfJointInterfaces, "");
+  lcm_pose_msg.joint_position.assign(numberOfJointInterfaces, 0.);
+  lcm_pose_msg.joint_velocity.assign(numberOfJointInterfaces, 0.);
+  lcm_pose_msg.joint_effort.assign(numberOfJointInterfaces, 0.);
 
       // VAL_COMMAND_FEEDBACK
-      bot_core::joint_state_t lcm_commanded_msg;
-      lcm_commanded_msg.utime = utime;
-      lcm_commanded_msg.num_joints = numberOfJointInterfaces;
-      lcm_commanded_msg.joint_name.assign(numberOfJointInterfaces, "");
-      lcm_commanded_msg.joint_position.assign(numberOfJointInterfaces, 0.);
-      lcm_commanded_msg.joint_velocity.assign(numberOfJointInterfaces, 0.);
-      lcm_commanded_msg.joint_effort.assign(numberOfJointInterfaces, 0.);
+  bot_core::joint_state_t lcm_commanded_msg;
+  lcm_commanded_msg.utime = utime;
+  lcm_commanded_msg.num_joints = numberOfJointInterfaces;
+  lcm_commanded_msg.joint_name.assign(numberOfJointInterfaces, "");
+  lcm_commanded_msg.joint_position.assign(numberOfJointInterfaces, 0.);
+  lcm_commanded_msg.joint_velocity.assign(numberOfJointInterfaces, 0.);
+  lcm_commanded_msg.joint_effort.assign(numberOfJointInterfaces, 0.);
 
       // VAL_COMMAND_FEEDBACK_TORQUE
       // TODO: add the position elements here, even though they aren't torques
-      bot_core::joint_angles_t lcm_torque_msg;
-      lcm_torque_msg.robot_name = "val!";
-      lcm_torque_msg.utime = utime;
-      lcm_torque_msg.num_joints = effortJointHandles.size();
-      lcm_torque_msg.joint_name.assign(effortJointHandles.size(), "");
-      lcm_torque_msg.joint_position.assign(effortJointHandles.size(), 0.);
+  bot_core::joint_angles_t lcm_torque_msg;
+  lcm_torque_msg.robot_name = "val!";
+  lcm_torque_msg.utime = utime;
+  lcm_torque_msg.num_joints = effortJointHandles.size();
+  lcm_torque_msg.joint_name.assign(effortJointHandles.size(), "");
+  lcm_torque_msg.joint_position.assign(effortJointHandles.size(), 0.);
 
       // EST_ROBOT_STATE
       // need to decide what message we're really using for state. for now,
       // assembling this to make director happy
-      bot_core::robot_state_t lcm_state_msg;
-      lcm_state_msg.utime = utime;
-      lcm_state_msg.num_joints = numberOfJointInterfaces;
-      lcm_state_msg.joint_name.assign(numberOfJointInterfaces, "");
-      lcm_state_msg.joint_position.assign(numberOfJointInterfaces, 0.);
-      lcm_state_msg.joint_velocity.assign(numberOfJointInterfaces, 0.);
-      lcm_state_msg.joint_effort.assign(numberOfJointInterfaces, 0.);
-      lcm_state_msg.pose.translation.x = 0.0;
-      lcm_state_msg.pose.translation.y = 0.0;
-      lcm_state_msg.pose.translation.z = 0.0;
-      lcm_state_msg.pose.rotation.w = 1.0;
-      lcm_state_msg.pose.rotation.x = 0.0;
-      lcm_state_msg.pose.rotation.y = 0.0;
-      lcm_state_msg.pose.rotation.z = 0.0;
-      lcm_state_msg.twist.linear_velocity.x = 0.0;
-      lcm_state_msg.twist.linear_velocity.y = 0.0;
-      lcm_state_msg.twist.linear_velocity.z = 0.0;
-      lcm_state_msg.twist.angular_velocity.x = 0.0;
-      lcm_state_msg.twist.angular_velocity.y = 0.0;
-      lcm_state_msg.twist.angular_velocity.z = 0.0;
+  bot_core::robot_state_t lcm_state_msg;
+  lcm_state_msg.utime = utime;
+  lcm_state_msg.num_joints = numberOfJointInterfaces;
+  lcm_state_msg.joint_name.assign(numberOfJointInterfaces, "");
+  lcm_state_msg.joint_position.assign(numberOfJointInterfaces, 0.);
+  lcm_state_msg.joint_velocity.assign(numberOfJointInterfaces, 0.);
+  lcm_state_msg.joint_effort.assign(numberOfJointInterfaces, 0.);
+  lcm_state_msg.pose.translation.x = 0.0;
+  lcm_state_msg.pose.translation.y = 0.0;
+  lcm_state_msg.pose.translation.z = 0.0;
+  lcm_state_msg.pose.rotation.w = 1.0;
+  lcm_state_msg.pose.rotation.x = 0.0;
+  lcm_state_msg.pose.rotation.y = 0.0;
+  lcm_state_msg.pose.rotation.z = 0.0;
+  lcm_state_msg.twist.linear_velocity.x = 0.0;
+  lcm_state_msg.twist.linear_velocity.y = 0.0;
+  lcm_state_msg.twist.linear_velocity.z = 0.0;
+  lcm_state_msg.twist.angular_velocity.x = 0.0;
+  lcm_state_msg.twist.angular_velocity.y = 0.0;
+  lcm_state_msg.twist.angular_velocity.z = 0.0;
 
 
       // Iterate over all effort-controlled joints
-      size_t effortJointIndex = 0;
-      for(auto iter = effortJointHandles.begin(); iter != effortJointHandles.end(); iter++)
-      {
+  size_t effortJointIndex = 0;
+  for(auto iter = effortJointHandles.begin(); iter != effortJointHandles.end(); iter++)
+  {
           // see drc_joint_command_t.lcm for explanation of gains and
           // force calculation.
-          double q = iter->second.getPosition();
-          double qd = iter->second.getVelocity();
-          double f = iter->second.getEffort();
+    double q = iter->second.getPosition();
+    double qd = iter->second.getVelocity();
+    double f = iter->second.getEffort();
 
-          joint_command& command = latest_commands[iter->first];
-          double command_effort =
-            command.k_q_p * ( command.position - q ) +
-            command.k_q_i * ( command.position - q ) * dt +
-            command.k_qd_p * ( command.velocity - qd) +
-            command.k_f_p * ( command.effort - f) +
-            command.ff_qd * ( qd ) +
-            command.ff_qd_d * ( command.velocity ) +
-            command.ff_f_d * ( command.effort ) +
-            command.ff_const;
+    joint_command& command = latest_commands[iter->first];
+    double command_effort =
+    command.k_q_p * ( command.position - q ) +
+    command.k_q_i * ( command.position - q ) * dt +
+    command.k_qd_p * ( command.velocity - qd) +
+    command.k_f_p * ( command.effort - f) +
+    command.ff_qd * ( qd ) +
+    command.ff_qd_d * ( command.velocity ) +
+    command.ff_f_d * ( command.effort ) +
+    command.ff_const;
 
 
           // only apply this command to the robot if this flag is set to true
-          if(applyEffortCommands){
+    if(applyEffortCommands){
 
-          if (fabs(command_effort) < 1000.){
-              iter->second.setCommand(command_effort);
-            } else{
-              ROS_INFO("Dangerous latest_commands[%s]: %f\n", iter->first.c_str(), command_effort);
-              iter->second.setCommand(0.0);
-            }
-          }
+      if (fabs(command_effort) < 1000.){
+        iter->second.setCommand(command_effort);
+      } else{
+        ROS_INFO("Dangerous latest_commands[%s]: %f\n", iter->first.c_str(), command_effort);
+        iter->second.setCommand(0.0);
+      }
+    }
 
 
-          lcm_pose_msg.joint_name[effortJointIndex] = iter->first;
-          lcm_pose_msg.joint_position[effortJointIndex] = q;
-          lcm_pose_msg.joint_velocity[effortJointIndex] = qd;
+    lcm_pose_msg.joint_name[effortJointIndex] = iter->first;
+    lcm_pose_msg.joint_position[effortJointIndex] = q;
+    lcm_pose_msg.joint_velocity[effortJointIndex] = qd;
           lcm_pose_msg.joint_effort[effortJointIndex] = iter->second.getEffort(); // measured!
 
           lcm_state_msg.joint_name[effortJointIndex] = iter->first;
@@ -318,16 +318,18 @@ namespace valkyrie_translator
           lcm_torque_msg.joint_position[effortJointIndex] = command_effort;
 
           effortJointIndex++;
-      }
+        }
 
       // Iterate over all position-controlled joints
-      size_t positionJointIndex = effortJointIndex;
-      for (auto iter = positionJointHandles.begin(); iter != positionJointHandles.end(); iter++) {
+        size_t positionJointIndex = effortJointIndex;
+        for (auto iter = positionJointHandles.begin(); iter != positionJointHandles.end(); iter++) {
           double q = iter->second.getPosition();
           double qd = iter->second.getVelocity();
 
           joint_command& command = latest_commands[iter->first];
           double position_to_go = command.position;
+
+          if(applyEffortCommands){
 
           // TODO: check that desired q is within limits
           if (fabs(position_to_go) < M_PI) { // TODO: check joint limit!
@@ -336,23 +338,24 @@ namespace valkyrie_translator
             ROS_INFO("Dangerous latest_commands[%s]: %f\n", iter->first.c_str(), position_to_go);
             // iter->second.setCommand(0.0); // Don't do anything!
           }
+        }
           // TODO: we can't directly iterate like this, better match differently!!
 
-          lcm_pose_msg.joint_name[positionJointIndex] = iter->first;
-          lcm_pose_msg.joint_position[positionJointIndex] = q;
-          lcm_pose_msg.joint_velocity[positionJointIndex] = qd;
+        lcm_pose_msg.joint_name[positionJointIndex] = iter->first;
+        lcm_pose_msg.joint_position[positionJointIndex] = q;
+        lcm_pose_msg.joint_velocity[positionJointIndex] = qd;
 
-          lcm_state_msg.joint_name[positionJointIndex] = iter->first;
-          lcm_state_msg.joint_position[positionJointIndex] = q;
-          lcm_state_msg.joint_velocity[positionJointIndex] = qd;
+        lcm_state_msg.joint_name[positionJointIndex] = iter->first;
+        lcm_state_msg.joint_position[positionJointIndex] = q;
+        lcm_state_msg.joint_velocity[positionJointIndex] = qd;
 
           // republish to guarantee sync
-          lcm_commanded_msg.joint_name[positionJointIndex] = iter->first;
-          lcm_commanded_msg.joint_position[positionJointIndex] = command.position;
-          lcm_commanded_msg.joint_velocity[positionJointIndex] = command.velocity;
-          lcm_commanded_msg.joint_effort[positionJointIndex] = command.effort;
+        lcm_commanded_msg.joint_name[positionJointIndex] = iter->first;
+        lcm_commanded_msg.joint_position[positionJointIndex] = command.position;
+        lcm_commanded_msg.joint_velocity[positionJointIndex] = command.velocity;
+        lcm_commanded_msg.joint_effort[positionJointIndex] = command.effort;
 
-          positionJointIndex++;
+        positionJointIndex++;
       }
 
       if(publishCoreRobotState){
@@ -423,23 +426,23 @@ namespace valkyrie_translator
         lcm_->publish("VAL_FORCE_TORQUE", &lcm_ft_array_msg);  
       }
       
-   }
+    }
 
-   void LCM2ROSControl::stopping(const ros::Time& time)
-   {}
+    void LCM2ROSControl::stopping(const ros::Time& time)
+    {}
 
-   LCM2ROSControl_LCMHandler::LCM2ROSControl_LCMHandler(LCM2ROSControl& parent) : parent_(parent) {
+    LCM2ROSControl_LCMHandler::LCM2ROSControl_LCMHandler(LCM2ROSControl& parent) : parent_(parent) {
       lcm_ = std::shared_ptr<lcm::LCM>(new lcm::LCM);
       if (!lcm_->good())
       {
         std::cerr << "ERROR: handler lcm is not good()" << std::endl;
       }
       lcm_->subscribe("ROBOT_COMMAND", &LCM2ROSControl_LCMHandler::jointCommandHandler, this);
-   }
-   LCM2ROSControl_LCMHandler::~LCM2ROSControl_LCMHandler() {}
+    }
+    LCM2ROSControl_LCMHandler::~LCM2ROSControl_LCMHandler() {}
 
-   void LCM2ROSControl_LCMHandler::jointCommandHandler(const lcm::ReceiveBuffer* rbuf, const std::string &channel,
-                               const bot_core::atlas_command_t* msg) {
+    void LCM2ROSControl_LCMHandler::jointCommandHandler(const lcm::ReceiveBuffer* rbuf, const std::string &channel,
+     const bot_core::atlas_command_t* msg) {
       // TODO: zero non-mentioned joints for safety?
 
       for (unsigned int i = 0; i < msg->num_joints; ++i) {
@@ -462,10 +465,10 @@ namespace valkyrie_translator
           // ROS_WARN("had no match.");
         }
       }
-   }
-   void LCM2ROSControl_LCMHandler::update(){
+    }
+    void LCM2ROSControl_LCMHandler::update(){
       lcm_->handleTimeout(0);
-   }
-}
+    }
+  }
 
-PLUGINLIB_EXPORT_CLASS(valkyrie_translator::LCM2ROSControl, controller_interface::ControllerBase)
+  PLUGINLIB_EXPORT_CLASS(valkyrie_translator::LCM2ROSControl, controller_interface::ControllerBase)

--- a/src/LCM2ROSControl.cpp
+++ b/src/LCM2ROSControl.cpp
@@ -320,9 +320,11 @@ void LCM2ROSControl::update(const ros::Time& time, const ros::Duration& period)
     joint_limits_interface::JointLimits limits;
     if (limits_search == joint_limits.end()){
             // defaults
-      limits.min_position = -DEFAULT_MIN_POSITION;
-      limits.max_position = DEFAULT_MIN_POSITION;
+      limits.min_position = DEFAULT_MIN_POSITION;
+      limits.max_position = DEFAULT_MAX_POSITION;
       limits.max_effort = DEFAULT_MAX_EFFORT;
+    } else {
+      limits = limits_search->second;
     }
 
           // bound the force within our max force limits
@@ -335,7 +337,7 @@ void LCM2ROSControl::update(const ros::Time& time, const ros::Duration& period)
       command_effort = 0.0;
     }
     else if (err_beyond_bound >= 0){              
-      ROS_INFO("Dangerous command modified: joint %s force %f scaled due to joint out of range %f\n", iter->first.c_str(), command_effort, q);
+     ROS_INFO("Dangerous command modified: joint %s force %f scaled due to joint out of range %f\n", iter->first.c_str(), command_effort, q);
             command_effort *= (FORCE_CONTROL_ALLOWABLE_POSITION_ERR_BOUND - err_beyond_bound) / FORCE_CONTROL_ALLOWABLE_POSITION_ERR_BOUND; // start at no scaling, scale down to 0 at ERR_BOUND
           }
 
@@ -396,8 +398,8 @@ void LCM2ROSControl::update(const ros::Time& time, const ros::Duration& period)
           joint_limits_interface::JointLimits limits;
           if (limits_search == joint_limits.end()){
             // defaults
-            limits.min_position = -DEFAULT_MIN_POSITION;
-            limits.max_position = DEFAULT_MIN_POSITION;
+            limits.min_position = DEFAULT_MIN_POSITION;
+            limits.max_position = DEFAULT_MAX_POSITION;
             limits.max_effort = DEFAULT_MAX_EFFORT;
           }
           if (position_to_go > limits.max_position || position_to_go < limits.min_position)

--- a/src/LCM2ROSControl.cpp
+++ b/src/LCM2ROSControl.cpp
@@ -285,12 +285,18 @@ namespace valkyrie_translator
             command.ff_f_d * ( command.effort ) +
             command.ff_const;
 
+
+          // only apply this command to the robot if this flag is set to true
+          if(applyEffortCommands){
+
           if (fabs(command_effort) < 1000.){
-            iter->second.setCommand(command_effort);
-          } else{
-            ROS_INFO("Dangerous latest_commands[%s]: %f\n", iter->first.c_str(), command_effort);
-            iter->second.setCommand(0.0);
+              iter->second.setCommand(command_effort);
+            } else{
+              ROS_INFO("Dangerous latest_commands[%s]: %f\n", iter->first.c_str(), command_effort);
+              iter->second.setCommand(0.0);
+            }
           }
+
 
           lcm_pose_msg.joint_name[effortJointIndex] = iter->first;
           lcm_pose_msg.joint_position[effortJointIndex] = q;
@@ -349,10 +355,16 @@ namespace valkyrie_translator
           positionJointIndex++;
       }
 
-      lcm_->publish("VAL_CORE_ROBOT_STATE", &lcm_pose_msg);
-      lcm_->publish("VAL_COMMAND_FEEDBACK", &lcm_commanded_msg);
-      lcm_->publish("VAL_COMMAND_FEEDBACK_TORQUE", &lcm_torque_msg);
-      lcm_->publish("EST_ROBOT_STATE", &lcm_state_msg);
+      if(publishCoreRobotState){
+        lcm_->publish("VAL_CORE_ROBOT_STATE", &lcm_pose_msg);
+        lcm_->publish("VAL_COMMAND_FEEDBACK", &lcm_commanded_msg);
+        lcm_->publish("VAL_COMMAND_FEEDBACK_TORQUE", &lcm_torque_msg);
+      }
+
+      if(publish_EST_ROBOT_STATE){
+        lcm_->publish("EST_ROBOT_STATE", &lcm_state_msg);
+      }      
+      
 
       // push out the measurements for all imus we see advertised
       for (auto iter = imuSensorHandles.begin(); iter != imuSensorHandles.end(); iter ++){
@@ -381,7 +393,10 @@ namespace valkyrie_translator
         lcm_imu_msg.pressure = 0.0;
         lcm_imu_msg.rel_alt = 0.0;
 
-        lcm_->publish(imuchannel.str(), &lcm_imu_msg);
+        if(publishCoreRobotState){
+          lcm_->publish(imuchannel.str(), &lcm_imu_msg);
+        }
+        
       }
 
       // push out the measurements for all ft's we see advertised
@@ -403,7 +418,11 @@ namespace valkyrie_translator
         lcm_ft_array_msg.names[i] = iter->first;
         i++;
       }
-      lcm_->publish("VAL_FORCE_TORQUE", &lcm_ft_array_msg);
+
+      if(publishCoreRobotState){
+        lcm_->publish("VAL_FORCE_TORQUE", &lcm_ft_array_msg);  
+      }
+      
    }
 
    void LCM2ROSControl::stopping(const ros::Time& time)

--- a/src/LCM2ROSControl.hpp
+++ b/src/LCM2ROSControl.hpp
@@ -72,6 +72,9 @@ namespace valkyrie_translator
         // Public so it can be modified by the LCMHandler. Should eventually create
         // a friend class arrangement to make this private again.
         std::map<std::string, joint_command> latest_commands;
+        bool publishCoreRobotState = true;
+        bool publish_EST_ROBOT_STATE = false;
+        bool applyEffortCommands = false;
 
    protected:
         virtual bool initRequest(hardware_interface::RobotHW* robot_hw,

--- a/src/LCM2ROSControl.hpp
+++ b/src/LCM2ROSControl.hpp
@@ -79,7 +79,7 @@ namespace valkyrie_translator
         bool applyCommands = false;
 
         double FORCE_CONTROL_ALLOWABLE_POSITION_ERR_BOUND = 0.1;
-        double FORCE_CONTROL_MAX_CHANGE = 1.0;
+        double FORCE_CONTROL_MAX_CHANGE = 100.0;
         double DEFAULT_MIN_POSITION = -M_PI;
         double DEFAULT_MAX_POSITION = M_PI;
         double DEFAULT_MAX_EFFORT = 1000.0;

--- a/src/LCM2ROSControl.hpp
+++ b/src/LCM2ROSControl.hpp
@@ -7,6 +7,8 @@
 #include <controller_interface/controller.h>
 #include <pluginlib/class_list_macros.h>
 #include <ros/node_handle.h>
+#include <joint_limits_interface/joint_limits.h>
+#include <joint_limits_interface/joint_limits_rosparam.h>
 
 #include <lcm/lcm-cpp.hpp>
 #include "lcmtypes/bot_core/joint_state_t.hpp"
@@ -73,8 +75,16 @@ namespace valkyrie_translator
         // a friend class arrangement to make this private again.
         std::map<std::string, joint_command> latest_commands;
         bool publishCoreRobotState = true;
-        bool publish_EST_ROBOT_STATE = false;
-        bool applyEffortCommands = false;
+        bool publish_est_robot_state = false;
+        bool applyCommands = false;
+
+        double FORCE_CONTROL_ALLOWABLE_POSITION_ERR_BOUND = 0.1;
+        double FORCE_CONTROL_MAX_CHANGE = 1.0;
+        double DEFAULT_MIN_POSITION = -M_PI;
+        double DEFAULT_MAX_POSITION = M_PI;
+        double DEFAULT_MAX_EFFORT = 1000.0;
+
+        std::map<std::string, joint_limits_interface::JointLimits> joint_limits;
 
    protected:
         virtual bool initRequest(hardware_interface::RobotHW* robot_hw,


### PR DESCRIPTION
Hands behave poorly if fingers are driven to positions lower than ~0.5, so I've added that as the lower bound for the moment.

Adds force and position bounding for LCM2ROSControl to prevent it from applying forces out of bounds. We need to populate more precise force and joint limits per-joint; right now defaults to the old |q| < 3.14 and |force| < 1000.

And adds some general options enabling us to use LCM2ROSControl for running the MIT controller.
