### PR TITLE
WIP: smooth behavior transitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ include_directories(
 ######################################################
 add_library(LCM2ROSControl src/LCM2ROSControl.cpp)
 target_link_libraries(LCM2ROSControl ${catkin_LIBRARIES} )
-pods_use_pkg_config_packages(LCM2ROSControl lcm lcmtypes_bot2-core)
+pods_use_pkg_config_packages(LCM2ROSControl lcm lcmtypes_bot2-core lcmtypes_drc_lcmtypes)
 
 add_library(JointPositionGoalController src/JointPositionGoalController.cpp)
 target_link_libraries(JointPositionGoalController ${catkin_LIBRARIES})

--- a/config/WholeBodyControl.yaml
+++ b/config/WholeBodyControl.yaml
@@ -50,4 +50,1070 @@ LCM2ROSControl:
         max_position: 1.5
         has_effort_limits: true
         max_effort: 100.0
-         
+
+  gain_overrides:
+    freeze:
+      hokuyo_joint:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftAnklePitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 68.0
+        k_qd_p: 6.29
+      leftAnkleRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 56.0
+        k_qd_p: 3.14
+      leftElbowPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 40.0
+        k_qd_p: 10.0
+      leftForearmYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftHipPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 550.0
+        k_qd_p: 21.0
+      leftHipRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 500.0
+        k_qd_p: 25.0
+      leftHipYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 100.0
+        k_qd_p: 6.2
+      leftIndexFingerPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftIndexFingerPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftIndexFingerPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftKneePitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 259.0
+        k_qd_p: 9.4
+      leftMiddleFingerPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftMiddleFingerPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftMiddleFingerPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftPinkyPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftPinkyPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftPinkyPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftShoulderPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 50.0
+        k_qd_p: 5.0
+      leftShoulderRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 50.0
+        k_qd_p: 5.0
+      leftShoulderYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 40.0
+        k_qd_p: 4.0
+      leftThumbPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftThumbPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftThumbPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftThumbRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftWristPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftWristRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      lowerNeckPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      neckYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightAnklePitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 68.0
+        k_qd_p: 6.29
+      rightAnkleRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 56.0
+        k_qd_p: 3.14
+      rightElbowPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 40.0
+        k_qd_p: 4.0
+      rightForearmYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightHipPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 550.0
+        k_qd_p: 21.0
+      rightHipRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 500.0
+        k_qd_p: 25.0
+      rightHipYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 100.0
+        k_qd_p: 6.2
+      rightIndexFingerPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightIndexFingerPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightIndexFingerPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightKneePitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 259.0
+        k_qd_p: 9.4
+      rightMiddleFingerPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightMiddleFingerPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightMiddleFingerPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightPinkyPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightPinkyPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightPinkyPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightShoulderPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 50.0
+        k_qd_p: 5.0
+      rightShoulderRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 50.0
+        k_qd_p: 5.0
+      rightShoulderYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 40.0
+        k_qd_p: 4.0
+      rightThumbPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightThumbPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightThumbPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightThumbRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightWristPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightWristRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      torsoPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 600.0
+        k_qd_p: 40.0
+      torsoRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 600.0
+        k_qd_p: 40.0
+      torsoYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 100.0
+        k_qd_p: 6.2
+      upperNeckPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+
+    position_control:
+      hokuyo_joint:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftAnklePitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 68.0
+        k_qd_p: 6.29
+      leftAnkleRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 56.0
+        k_qd_p: 3.14
+      leftElbowPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 40.0
+        k_qd_p: 10.0
+      leftForearmYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftHipPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 550.0
+        k_qd_p: 21.0
+      leftHipRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 500.0
+        k_qd_p: 25.0
+      leftHipYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 100.0
+        k_qd_p: 6.2
+      leftIndexFingerPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftIndexFingerPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftIndexFingerPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftKneePitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 259.0
+        k_qd_p: 9.4
+      leftMiddleFingerPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftMiddleFingerPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftMiddleFingerPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftPinkyPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftPinkyPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftPinkyPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftShoulderPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 50.0
+        k_qd_p: 5.0
+      leftShoulderRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 50.0
+        k_qd_p: 5.0
+      leftShoulderYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 40.0
+        k_qd_p: 4.0
+      leftThumbPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftThumbPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftThumbPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftThumbRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftWristPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      leftWristRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      lowerNeckPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      neckYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightAnklePitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 68.0
+        k_qd_p: 6.29
+      rightAnkleRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 56.0
+        k_qd_p: 3.14
+      rightElbowPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 40.0
+        k_qd_p: 4.0
+      rightForearmYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightHipPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 550.0
+        k_qd_p: 21.0
+      rightHipRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 500.0
+        k_qd_p: 25.0
+      rightHipYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 100.0
+        k_qd_p: 6.2
+      rightIndexFingerPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightIndexFingerPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightIndexFingerPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightKneePitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 259.0
+        k_qd_p: 9.4
+      rightMiddleFingerPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightMiddleFingerPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightMiddleFingerPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightPinkyPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightPinkyPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightPinkyPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightShoulderPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 50.0
+        k_qd_p: 5.0
+      rightShoulderRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 50.0
+        k_qd_p: 5.0
+      rightShoulderYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 40.0
+        k_qd_p: 4.0
+      rightThumbPitch1:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightThumbPitch2:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightThumbPitch3:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightThumbRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightWristPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      rightWristRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0
+      torsoPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 600.0
+        k_qd_p: 40.0
+      torsoRoll:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 600.0
+        k_qd_p: 40.0
+      torsoYaw:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 100.0
+        k_qd_p: 6.2
+      upperNeckPitch:
+        ff_const: 0.0
+        ff_f_d: 0.0
+        ff_qd: 0.0
+        ff_qd_d: 0.0
+        k_f_p: 0.0
+        k_q_i: 0.0
+        k_q_p: 0.0
+        k_qd_p: 0.0

--- a/src/LCM2ROSControl.cpp
+++ b/src/LCM2ROSControl.cpp
@@ -238,7 +238,7 @@ bool LCM2ROSControl::loadBehaviorGainOverrides(const std::vector<std::string>& e
     return false;
   }
 
-  std::vector<std::pair<Behavior, std::string> > behaviors = {{FREEZE, "freeze"}, {POSITION_CONTROL, "position_control"}};
+  std::vector<std::pair<Behavior, std::string> > behaviors = {{Behavior::FREEZE, "freeze"}, {Behavior::POSITION_CONTROL, "position_control"}};
   for (auto iter = behaviors.begin(); iter != behaviors.end(); ++iter) {
     if (!gain_overrides.hasMember(iter->second)) {
       ROS_ERROR_STREAM("Could not find gain overrides for behavior " << iter->second);
@@ -500,18 +500,18 @@ double LCM2ROSControl::commandEffort(const std::string& joint_name, const hardwa
       q_desired = command.position;
       qd_desired = 0.0;
       f_desired = 0.0;
-      gains = behavior_gain_overrides[POSITION_CONTROL][joint_name];
+      gains = behavior_gain_overrides[Behavior::POSITION_CONTROL][joint_name];
       break;
     case Behavior::FREEZE:
       q_desired = latched_positions[joint_name];
       qd_desired = 0.0;
-      gains = behavior_gain_overrides[FREEZE][joint_name];
+      gains = behavior_gain_overrides[Behavior::FREEZE][joint_name];
       break;
     default:
-      ROS_WARN_STREAM("Unknown behavior: " << behavior << ", treating it as FREEZE");
+      ROS_WARN_STREAM("Unknown behavior, treating it as FREEZE");
       q_desired = latched_positions[joint_name];
       qd_desired = 0.0;
-      gains = behavior_gain_overrides[FREEZE][joint_name];
+      gains = behavior_gain_overrides[Behavior::FREEZE][joint_name];
       break;
   }
 
@@ -598,17 +598,17 @@ void LCM2ROSControl::latchCurrentPositions() {
 
       switch (msg->behavior) {
         case msg->FREEZE:
-          parent_.transitionTo(FREEZE, duration);
+          parent_.transitionTo(Behavior::FREEZE, duration);
           break;
         case msg->POSITION_CONTROL:
-          parent_.transitionTo(POSITION_CONTROL, duration);
+          parent_.transitionTo(Behavior::POSITION_CONTROL, duration);
           break;
         case msg->NORMAL:
-          parent_.transitionTo(NORMAL, duration);
+          parent_.transitionTo(Behavior::NORMAL, duration);
           break;
         default:
           ROS_WARN_STREAM("Unknown behavior: " << msg->behavior << ", treating it as FREEZE");
-          parent_.transitionTo(FREEZE, duration);
+          parent_.transitionTo(Behavior::FREEZE, duration);
           break;
       }
     }

--- a/src/LCM2ROSControl.cpp
+++ b/src/LCM2ROSControl.cpp
@@ -561,6 +561,7 @@ void LCM2ROSControl::latchCurrentPositions() {
         std::cerr << "ERROR: handler lcm is not good()" << std::endl;
       }
       lcm_->subscribe("ROBOT_COMMAND", &LCM2ROSControl_LCMHandler::jointCommandHandler, this);
+      lcm_->subscribe("ROBOT_BEHAVIOR", &LCM2ROSControl_LCMHandler::behaviorHandler, this);
     }
     LCM2ROSControl_LCMHandler::~LCM2ROSControl_LCMHandler() {}
 
@@ -591,6 +592,25 @@ void LCM2ROSControl::latchCurrentPositions() {
     }
     void LCM2ROSControl_LCMHandler::update(){
       lcm_->handleTimeout(0);
+    }
+    void LCM2ROSControl_LCMHandler::behaviorHandler(const lcm::ReceiveBuffer* rbuf, const std::string &channel, const drc::behavior_transition_t* msg) {
+      ros::Duration duration(msg->transition_duration_s);
+
+      switch (msg->behavior) {
+        case msg->FREEZE:
+          parent_.transitionTo(FREEZE, duration);
+          break;
+        case msg->POSITION_CONTROL:
+          parent_.transitionTo(POSITION_CONTROL, duration);
+          break;
+        case msg->NORMAL:
+          parent_.transitionTo(NORMAL, duration);
+          break;
+        default:
+          ROS_WARN_STREAM("Unknown behavior: " << msg->behavior << ", treating it as FREEZE");
+          parent_.transitionTo(FREEZE, duration);
+          break;
+      }
     }
   }
 

--- a/src/LCM2ROSControl.cpp
+++ b/src/LCM2ROSControl.cpp
@@ -508,6 +508,7 @@ double LCM2ROSControl::commandEffort(const std::string& joint_name, const hardwa
       gains = behavior_gain_overrides[FREEZE][joint_name];
       break;
     default:
+      ROS_WARN_STREAM("Unknown behavior: " << behavior << ", treating it as FREEZE");
       q_desired = latched_positions[joint_name];
       qd_desired = 0.0;
       gains = behavior_gain_overrides[FREEZE][joint_name];

--- a/src/LCM2ROSControl.hpp
+++ b/src/LCM2ROSControl.hpp
@@ -29,13 +29,13 @@
 namespace valkyrie_translator
 {
 
-  enum Behavior {
+  enum class Behavior {
     FREEZE,
     POSITION_CONTROL,
     NORMAL
   };
 
-  typedef struct _joint_gains {
+  struct joint_gains {
     double k_q_p; // corresponds to kp_position in drcsim API
     double k_q_i; // corresponds to ki_position in drcsim API
     double k_qd_p; // corresponds to kp_velocity in drcsim API
@@ -44,15 +44,15 @@ namespace valkyrie_translator
     double ff_qd_d;
     double ff_f_d;
     double ff_const;
-  } joint_gains;
+  };
 
-   typedef struct _joint_command {
+   struct joint_command {
     double position;
     double velocity;
     double effort;
 
     joint_gains gains;
-   } joint_command;
+   };
 
    class LCM2ROSControl;
 

--- a/src/LCM2ROSControl.hpp
+++ b/src/LCM2ROSControl.hpp
@@ -127,6 +127,7 @@ namespace valkyrie_translator
 
         void latchCurrentPositions();
         bool loadBehaviorGainOverrides(const std::vector<std::string>& effort_names, const ros::NodeHandle& controller_nh);
+        double commandPosition(const std::string& joint_name, const joint_command& command, const Behavior& behavior);
         double commandEffort(const std::string& joint_name, const hardware_interface::JointHandle& joint_handle, const joint_command& command, const double dt, const Behavior& behavior);
         double currentTransitionRatio();
    };

--- a/src/LCM2ROSControl.hpp
+++ b/src/LCM2ROSControl.hpp
@@ -19,6 +19,7 @@
 #include "lcmtypes/bot_core/ins_t.hpp"
 #include "lcmtypes/bot_core/joint_angles_t.hpp"
 #include "lcmtypes/bot_core/atlas_command_t.hpp"
+#include "lcmtypes/drc/behavior_transition_t.hpp"
 
 #include <set>
 #include <string>
@@ -64,6 +65,8 @@ namespace valkyrie_translator
         virtual ~LCM2ROSControl_LCMHandler();
         void jointCommandHandler(const lcm::ReceiveBuffer* rbuf, const std::string &channel,
                                const bot_core::atlas_command_t* msg);
+        void behaviorHandler(const lcm::ReceiveBuffer* rbuf, const std::string &channel,
+                             const drc::behavior_transition_t* msg);
         void update();
    private:
         LCM2ROSControl& parent_;
@@ -97,6 +100,7 @@ namespace valkyrie_translator
         double DEFAULT_MAX_EFFORT = 1000.0;
 
         std::map<std::string, joint_limits_interface::JointLimits> joint_limits;
+        void transitionTo(Behavior new_behavior, ros::Duration transition_duration);
 
    protected:
         virtual bool initRequest(hardware_interface::RobotHW* robot_hw,
@@ -121,7 +125,6 @@ namespace valkyrie_translator
         ros::Duration last_transition_duration;
         std::map<Behavior, std::map<std::string, joint_gains> > behavior_gain_overrides;
 
-        void transitionTo(Behavior new_behavior, ros::Duration transition_duration);
         void latchCurrentPositions();
         bool loadBehaviorGainOverrides(const std::vector<std::string>& effort_names, const ros::NodeHandle& controller_nh);
         double commandEffort(const std::string& joint_name, const hardware_interface::JointHandle& joint_handle, const joint_command& command, const double dt, const Behavior& behavior);


### PR DESCRIPTION
This isn't ready for merge yet, but I want to at least show what I've got. 

This is the result of the discussion yesterday with @gizatt @tkoolen @manuelli . It implements FREEZE, POSITION_CONTROL, and NORMAL behaviors with LCM2ROSControl, and supports smooth transitions between them. It requires a new lcmtype in openhumanoids:

``` c
package drc;

// Causes a transition in the LCM2ROSControl process that drives Val

struct behavior_transition_t
{
    int64_t utime;
    int32_t behavior;
    double transition_duration_s;

    const int32_t FREEZE=0;
    const int32_t POSITION_CONTROL=1;
    const int32_t NORMAL=2;
}
```
